### PR TITLE
feat: add Homebrew formula support

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,71 @@
+name: Update Homebrew Formula
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  update-formula:
+    name: Update Homebrew formula
+    needs: []
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for PyPI to be available
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Waiting for xhs-cli==$VERSION on PyPI..."
+          for i in $(seq 1 30); do
+            if curl -sf "https://pypi.org/pypi/xhs-cli/$VERSION/json" > /dev/null 2>&1; then
+              echo "Package available on PyPI"
+              break
+            fi
+            echo "Attempt $i/30 - not yet available, waiting 30s..."
+            sleep 30
+          done
+
+      - name: Get PyPI release info
+        id: pypi
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          JSON=$(curl -sf "https://pypi.org/pypi/xhs-cli/$VERSION/json")
+          SDIST_URL=$(echo "$JSON" | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          for u in data['urls']:
+              if u['packagetype'] == 'sdist':
+                  print(u['url'])
+                  break
+          ")
+          SDIST_SHA=$(echo "$JSON" | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          for u in data['urls']:
+              if u['packagetype'] == 'sdist':
+                  print(u['digests']['sha256'])
+                  break
+          ")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "url=$SDIST_URL" >> "$GITHUB_OUTPUT"
+          echo "sha256=$SDIST_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Update formula
+        run: |
+          VERSION="${{ steps.pypi.outputs.version }}"
+          URL="${{ steps.pypi.outputs.url }}"
+          SHA256="${{ steps.pypi.outputs.sha256 }}"
+
+          sed -i "s|url \"https://files.pythonhosted.org/.*\"|url \"$URL\"|" Formula/xhs-cli.rb
+          sed -i "s|sha256 \"[a-f0-9]*\"|sha256 \"$SHA256\"|" Formula/xhs-cli.rb
+          sed -i "s|xhs-cli==[0-9.]*|xhs-cli==$VERSION|" Formula/xhs-cli.rb
+
+      - name: Commit and push
+        run: |
+          VERSION="${{ steps.pypi.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/xhs-cli.rb
+          git commit -m "brew: update xhs-cli to $VERSION" || exit 0
+          git push origin HEAD:main

--- a/Formula/xhs-cli.rb
+++ b/Formula/xhs-cli.rb
@@ -1,0 +1,40 @@
+class XhsCli < Formula
+  include Language::Python::Virtualenv
+
+  desc "CLI for Xiaohongshu (RedNote) - search, read notes, view profiles"
+  homepage "https://github.com/jackwener/xhs-cli"
+  url "https://files.pythonhosted.org/packages/59/68/9e4518eb56c5002fff53c2f15b0e8ab9526c9c21eb87c2a85f75276bd18b/xhs_cli-0.1.3.tar.gz"
+  sha256 "aadb83ab2f11143f85f31269b601a37ec2d548f3f4198e740825c35a2964de34"
+  license "Apache-2.0"
+
+  depends_on "python@3.13"
+
+  def install
+    python3 = "python3.13"
+    venv = libexec
+
+    # Create virtualenv WITH pip (needed to install wheel-only packages)
+    system python3, "-m", "venv", venv
+    system venv/"bin/pip", "install", "--upgrade", "pip"
+
+    # Install xhs-cli and all dependencies (allows binary wheels for packages
+    # that have no sdist: playwright, ua-parser-builtins, geoip2 via uv_build)
+    system venv/"bin/pip", "install", "xhs-cli==0.1.3"
+
+    # Symlink the CLI binary
+    bin.install_symlink venv/"bin/xhs"
+  end
+
+  def caveats
+    <<~EOS
+      xhs-cli requires the camoufox browser to function.
+      After installation, run once to download the browser:
+
+        #{libexec}/bin/python -m camoufox fetch
+    EOS
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/xhs --help")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@
 需要 Python 3.8+。
 
 ```bash
-# 推荐：使用 uv
+# 推荐：使用 Homebrew (macOS)
+brew install jackwener/xhs/xhs-cli
+
+# 使用 uv
 uv tool install xhs-cli
 
 # 或使用 pipx

--- a/README_EN.md
+++ b/README_EN.md
@@ -43,7 +43,10 @@ A command-line tool for [Xiaohongshu (小红书)](https://www.xiaohongshu.com) �
 Requires Python 3.8+.
 
 ```bash
-# Recommended: using uv
+# Recommended: using Homebrew (macOS)
+brew install jackwener/xhs/xhs-cli
+
+# Using uv
 uv tool install xhs-cli
 
 # Or using pipx


### PR DESCRIPTION
## Summary

- Add `Formula/xhs-cli.rb` Homebrew formula so users can install with `brew install jackwener/xhs/xhs-cli`
- Add `.github/workflows/update-homebrew.yml` to auto-update the formula when a new version tag is pushed
- Update both READMEs with Homebrew installation instructions

## How it works

The repo itself acts as a [Homebrew tap](https://docs.brew.sh/Taps). Users can install directly with:

```bash
brew install jackwener/xhs/xhs-cli
```

Or tap first:

```bash
brew tap jackwener/xhs
brew install xhs-cli
```

### Formula approach

The formula creates a Python virtualenv and uses `pip install xhs-cli` (with binary wheels allowed). This is needed because several transitive dependencies have no sdist on PyPI:
- `playwright` — wheel-only
- `ua-parser-builtins` — wheel-only  
- `geoip2` — uses `uv_build` (Rust-based), can't build from source in Homebrew sandbox

### Auto-update workflow

When a new version tag (e.g., `v0.1.4`) is pushed, the `update-homebrew.yml` workflow:
1. Waits for the package to appear on PyPI
2. Fetches the new sdist URL and SHA256
3. Updates `Formula/xhs-cli.rb` with the new version
4. Commits and pushes to main

## Test plan

- [x] Tested `brew install` locally — installs successfully
- [x] `xhs --help` works after installation
- [ ] Test auto-update workflow on next release