### PR TITLE
[codex] Add creator preflight checks and real-Chrome publish fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ xhs favorites --max 10
 ```bash
 xhs post "标题" --image photo1.jpg --image photo2.jpg --content "正文内容"
 xhs post "标题" --image photo1.jpg --content "正文内容" --json
+
+# 真实 Chrome 会话发布（适合 creator 会话无法被 cookie 注入复用时）
+xhs post-real "标题" --image photo1.jpg --content "正文内容"
+xhs post-real "标题" --image photo1.jpg --content "正文内容" --cdp-url http://127.0.0.1:9222
 ```
 
 ### 其他
@@ -252,6 +256,9 @@ git clone git@github.com:jackwener/xhs-cli.git .agents/skills/xhs-cli
 - `xhs login --cookie` 要求 cookie 至少包含 `a1` 和 `web_session`。
 - 登录后会自动做可用性探活；若会话仍为 guest/风控受限，会提示重新登录。
 - `xhs post` 可能要求额外登录创作平台（`https://creator.xiaohongshu.com`）。
+- 如果 `xhs post` 提示 creator 登录，但你在真实 Chrome 已登录，可改用 `xhs post-real`。
+- `xhs post-real` 需要先把真实 Chrome 以远程调试模式启动，例如：
+  `/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222 --profile-directory=Default`
 - 使用 headless Firefox，不会弹出浏览器窗口。
 - 首次运行需下载 camoufox 浏览器（`python -m camoufox fetch`）。
 - 用户资料查询需要内部 user_id（十六进制），不是小红书号。

--- a/README_EN.md
+++ b/README_EN.md
@@ -186,6 +186,10 @@ xhs favorites --max 10
 ```bash
 xhs post "Title" --image photo1.jpg --image photo2.jpg --content "Body text"
 xhs post "Title" --image photo1.jpg --content "Body text" --json
+
+# Publish through a real Chrome session (when creator login cannot be reused via injected cookies)
+xhs post-real "Title" --image photo1.jpg --content "Body text"
+xhs post-real "Title" --image photo1.jpg --content "Body text" --cdp-url http://127.0.0.1:9222
 ```
 
 ### Other
@@ -250,6 +254,9 @@ All xhs-cli commands are available in OpenClaw after installation.
 - `xhs login --cookie` requires at least `a1` and `web_session`.
 - Login runs a usability probe; guest/risk-limited sessions are treated as invalid and require re-login.
 - `xhs post` may require an extra creator-platform login at `https://creator.xiaohongshu.com`.
+- If `xhs post` says creator login is required but your real Chrome is already logged in, try `xhs post-real`.
+- `xhs post-real` requires real Chrome to be started with remote debugging enabled, for example:
+  `/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222 --profile-directory=Default`
 - Uses headless Firefox via camoufox — no browser window is shown.
 - First run requires downloading the camoufox browser (`python -m camoufox fetch`).
 - User profile lookup requires the internal user_id (hex format), not the Red ID.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import xhs_cli.cli as cli_module
 from xhs_cli import __version__
 from xhs_cli.cli import cli
 from xhs_cli.exceptions import DataFetchError
+from xhs_cli.real_chrome import build_cdp_launch_help
 
 
 @pytest.fixture
@@ -48,6 +49,11 @@ class TestCliHelp:
         assert "--image" in result.output
         assert "--content" in result.output
         assert "--json" in result.output
+
+    def test_post_real_help(self, runner):
+        result = runner.invoke(cli, ["post-real", "--help"])
+        assert result.exit_code == 0
+        assert "--cdp-url" in result.output
 
     def test_favorites_help(self, runner):
         result = runner.invoke(cli, ["favorites", "--help"])
@@ -289,6 +295,39 @@ class TestProbeSessionUsability:
         assert cli_module._probe_session_usability({"a1": "x", "web_session": "y"}) is None
 
 
+class _FakeCreatorProbeClient:
+    def __init__(self, result=None, should_raise=False):
+        self._result = result
+        self._should_raise = should_raise
+
+    def __enter__(self):
+        if self._should_raise:
+            raise RuntimeError("boom")
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def probe_creator_publish_access(self):
+        return self._result
+
+
+class TestProbeCreatorPublishAccess:
+    def test_probe_creator_success(self, monkeypatch):
+        monkeypatch.setattr(
+            "xhs_cli.client.XhsClient",
+            lambda _cookie_dict: _FakeCreatorProbeClient(result=True),
+        )
+        assert cli_module._probe_creator_publish_access({"a1": "x", "web_session": "y"}) is True
+
+    def test_probe_creator_transient_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "xhs_cli.client.XhsClient",
+            lambda _cookie_dict: _FakeCreatorProbeClient(should_raise=True),
+        )
+        assert cli_module._probe_creator_publish_access({"a1": "x", "web_session": "y"}) is None
+
+
 class _FakeDataClient:
     def search_notes(self, _keyword):
         return [
@@ -326,3 +365,74 @@ class TestCliRobustness:
         result = runner.invoke(cli, ["followers", "u123"])
         assert result.exit_code == 0
         assert "Followers" in result.output
+
+
+class _FakePostClient:
+    def __init__(self, creator_result=True, publish_result=None):
+        self.creator_result = creator_result
+        self.publish_result = publish_result if publish_result is not None else {
+            "success": True,
+            "note_id": "n123",
+        }
+        self.publish_called = False
+
+    def probe_creator_publish_access(self):
+        return self.creator_result
+
+    def publish_note(self, **_kwargs):
+        self.publish_called = True
+        return self.publish_result
+
+
+class TestPostCommand:
+    def test_post_blocks_early_when_creator_access_missing(self, runner, tmp_path, monkeypatch):
+        image = tmp_path / "cover.jpg"
+        image.write_bytes(b"jpg")
+        fake_client = _FakePostClient(creator_result=False)
+        monkeypatch.setattr(cli_module, "_get_client", lambda: _fake_client_ctx(fake_client))
+
+        result = runner.invoke(
+            cli,
+            ["post", "标题", "--image", str(image), "--content", "正文"],
+        )
+
+        assert result.exit_code == 1
+        assert "creator.xiaohongshu.com/login" in result.output
+        assert fake_client.publish_called is False
+
+    def test_post_json_reports_creator_login_required(self, runner, tmp_path, monkeypatch):
+        image = tmp_path / "cover.jpg"
+        image.write_bytes(b"jpg")
+        fake_client = _FakePostClient(creator_result=False)
+        monkeypatch.setattr(cli_module, "_get_client", lambda: _fake_client_ctx(fake_client))
+
+        result = runner.invoke(
+            cli,
+            ["post", "标题", "--image", str(image), "--content", "正文", "--json"],
+        )
+
+        assert result.exit_code == 1
+        assert '"error": "creator_login_required"' in result.output
+        assert fake_client.publish_called is False
+
+
+class TestPostRealCommand:
+    def test_post_real_reports_cdp_connection_help(self, runner, tmp_path, monkeypatch):
+        image = tmp_path / "cover.jpg"
+        image.write_bytes(b"jpg")
+
+        @contextmanager
+        def _fake_real_client(_cdp_url):
+            raise RuntimeError(build_cdp_launch_help("http://127.0.0.1:9222"))
+            yield  # pragma: no cover
+
+        monkeypatch.setattr(cli_module, "get_real_chrome_client", _fake_real_client)
+
+        result = runner.invoke(
+            cli,
+            ["post-real", "标题", "--image", str(image), "--content", "正文"],
+        )
+
+        assert result.exit_code == 1
+        assert "Cannot connect to real Chrome" in result.output
+        assert "--remote-debugging-port=9222" in result.output

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -44,6 +44,48 @@ class _FakeWaitPage:
         return self._body
 
 
+class _FakeHydratePage:
+    def __init__(self, html: str, url: str = "https://www.xiaohongshu.com/explore"):
+        self.url = url
+        self._html = html
+        self._hydrated = False
+
+    def evaluate(self, script, *args):
+        if args and "eval(scriptText)" in script:
+            self._hydrated = True
+            return True
+        if "window.__INITIAL_STATE__ !== undefined && window.__INITIAL_STATE__ !== null" in script:
+            if args:
+                self._hydrated = True
+                return True
+            return self._hydrated
+        if "window.__INITIAL_STATE__ !== undefined" in script:
+            return self._hydrated
+        if "window.__INITIAL_STATE__" in script:
+            return self._hydrated
+        return False
+
+    def content(self):
+        return self._html
+
+    def text_content(self, _selector):
+        return ""
+
+
+class _FakeGotoPage:
+    def __init__(self, url: str):
+        self.url = url
+
+    def goto(self, url, *_args, **_kwargs):
+        self.url = url
+
+    def text_content(self, _selector):
+        return ""
+
+    def evaluate(self, _script, *_args):
+        return False
+
+
 class TestGetNoteComments:
     def test_extracts_note_comments_and_applies_max_limit(self):
         client = XhsClient({})
@@ -115,6 +157,37 @@ class TestPublishResultHeuristic:
         assert note_id == "xyz987"
 
 
+class TestCreatorPublishAccessProbe:
+    def test_probe_returns_false_after_creator_login_redirect(self, monkeypatch):
+        client = XhsClient({})
+        client._page = _FakeGotoPage(
+            "https://www.xiaohongshu.com/explore"
+        )
+
+        def _fake_goto(*_args, **_kwargs):
+            client._page.url = (
+                "https://creator.xiaohongshu.com/login"
+                "?source=&redirectReason=401&lastUrl=%252Fpublish%252Fpublish"
+            )
+
+        monkeypatch.setattr(client, "_goto", _fake_goto)
+
+        assert client.probe_creator_publish_access() is False
+
+    def test_probe_returns_true_when_publish_page_is_accessible(self, monkeypatch):
+        client = XhsClient({})
+        client._page = _FakeGotoPage("https://www.xiaohongshu.com/explore")
+        monkeypatch.setattr(
+            client,
+            "_goto",
+            lambda *_args, **_kwargs: setattr(
+                client._page, "url", "https://creator.xiaohongshu.com/publish/publish"
+            ),
+        )
+
+        assert client.probe_creator_publish_access() is True
+
+
 class TestGetUserInfoFallback:
     def test_returns_unwrapped_user_object_when_key_fields_missing(self, monkeypatch):
         client = XhsClient({})
@@ -167,3 +240,23 @@ class TestWaitForData:
                 desc="user profile",
                 raise_on_timeout=True,
             )
+
+    def test_wait_for_data_hydrates_initial_state_from_inline_html(self, monkeypatch):
+        client = XhsClient({})
+        client._page = _FakeHydratePage(
+            '<html><body><script>window.__INITIAL_STATE__={"feed":{"feeds":[{"id":"n1"}]}}</script></body></html>'
+        )
+        monkeypatch.setattr("xhs_cli.client.time.sleep", lambda *_args, **_kwargs: None)
+
+        client._wait_for_data(
+            "() => !!window.__INITIAL_STATE__",
+            timeout=0.5,
+            desc="feed.feeds",
+            raise_on_timeout=True,
+        )
+
+    def test_hydrate_initial_state_returns_false_when_no_inline_state(self):
+        client = XhsClient({})
+        client._page = _FakeHydratePage("<html><body><div>no state</div></body></html>")
+
+        assert client._hydrate_initial_state_from_html() is False

--- a/xhs_cli/cli.py
+++ b/xhs_cli/cli.py
@@ -33,7 +33,8 @@ from .auth import (
     qrcode_login,
     save_token_cache,
 )
-from .exceptions import DataFetchError
+from .exceptions import DataFetchError, LoginError
+from .real_chrome import DEFAULT_CHROME_CDP_URL, get_real_chrome_client
 
 if TYPE_CHECKING:
     from .client import XhsClient
@@ -129,7 +130,15 @@ def login(ctx: click.Context, qrcode: bool, cookie_str: str | None):
             if verify_result is True:
                 probe_result = _probe_session_usability(cookie_dict)
                 if probe_result is True:
-                    console.print("[green]✅ Logged in (from browser cookies)[/green]")
+                    console.print("[green]✅ Logged in (main site session available)[/green]")
+                    creator_result = _probe_creator_publish_access(cookie_dict)
+                    if creator_result is False:
+                        _print_creator_publish_warning()
+                    elif creator_result is None:
+                        console.print(
+                            "[yellow]⚠️  Unable to confirm creator publish access. "
+                            "Feed/search work, but `xhs post` may still fail.[/yellow]"
+                        )
                     return
                 if probe_result is False:
                     console.print(
@@ -168,6 +177,14 @@ def login(ctx: click.Context, qrcode: bool, cookie_str: str | None):
             )
             sys.exit(1)
         console.print("[green]✅ Login successful! Cookie saved.[/green]")
+        creator_result = _probe_creator_publish_access(cookie_dict)
+        if creator_result is False:
+            _print_creator_publish_warning()
+        elif creator_result is None:
+            console.print(
+                "[yellow]⚠️  Unable to confirm creator publish access. "
+                "Main site login succeeded, but `xhs post` may still fail.[/yellow]"
+            )
     except Exception as e:
         console.print(f"[red]❌ Login failed: {e}[/red]")
         sys.exit(1)
@@ -233,6 +250,100 @@ def _probe_session_usability(cookie_dict: dict) -> bool | None:
     if isinstance(feeds, list):
         return True
     return False
+
+
+def _probe_creator_publish_access(cookie_dict: dict) -> bool | None:
+    """Probe whether session can access creator publish page."""
+    from .client import XhsClient
+
+    try:
+        with XhsClient(cookie_dict) as client:
+            return client.probe_creator_publish_access()
+    except Exception as exc:
+        logger.warning("Creator publish probe failed due to transient error: %s", exc)
+        return None
+
+
+def _print_creator_publish_warning():
+    """Explain why posting can still fail even if the main site is logged in."""
+    console.print(
+        "[yellow]⚠️  Main site session is available, but creator publish access is not. "
+        "`xhs post` will fail if browser automation is redirected to "
+        "`creator.xiaohongshu.com/login`.[/yellow]"
+    )
+
+
+def _publish_note_with_client(
+    client,
+    *,
+    title: str,
+    abs_paths: list[str],
+    content: str,
+    as_json: bool,
+):
+    """Run publish flow with a prepared client."""
+    creator_result = client.probe_creator_publish_access()
+    if creator_result is False:
+        message = (
+            "Main site session is logged in, but the automated browser was redirected "
+            "to creator.xiaohongshu.com/login. Publishing requires a creator session "
+            "that browser automation can reuse."
+        )
+        if as_json:
+            click.echo(
+                json.dumps(
+                    {
+                        "success": False,
+                        "note_id": "",
+                        "error": "creator_login_required",
+                        "message": message,
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
+        else:
+            console.print(f"[red]❌ Publish blocked: {message}[/red]")
+        sys.exit(1)
+    if creator_result is None:
+        console.print(
+            "[yellow]⚠️  Unable to confirm creator publish access. "
+            "Attempting publish anyway...[/yellow]"
+        )
+
+    result = client.publish_note(
+        title=title,
+        image_paths=abs_paths,
+        content=content,
+        return_detail=True,
+    )
+    if isinstance(result, dict):
+        ok = bool(result.get("success", False))
+        note_id = str(result.get("note_id", ""))
+    else:
+        ok = bool(result)
+        note_id = ""
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {"success": ok, "note_id": note_id},
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        if not ok:
+            sys.exit(1)
+        return
+
+    if ok:
+        if note_id:
+            console.print(f"[green]✅ Note published successfully! Note ID: {note_id}[/green]")
+        else:
+            console.print("[green]✅ Note published successfully![/green]")
+    else:
+        console.print("[red]❌ Publish may have failed. Check your profile.[/red]")
+        sys.exit(1)
 
 
 @cli.command()
@@ -972,46 +1083,75 @@ def post(title: str, images: tuple[str, ...], content: str, as_json: bool):
 
     try:
         with _get_client() as client:
-            result = client.publish_note(
+            _publish_note_with_client(
+                client,
                 title=title,
-                image_paths=abs_paths,
+                abs_paths=abs_paths,
                 content=content,
-                return_detail=True,
+                as_json=as_json,
             )
-            if isinstance(result, dict):
-                ok = bool(result.get("success", False))
-                note_id = str(result.get("note_id", ""))
-            else:
-                ok = bool(result)
-                note_id = ""
-
-            if as_json:
-                click.echo(
-                    json.dumps(
-                        {"success": ok, "note_id": note_id},
-                        indent=2,
-                        ensure_ascii=False,
-                    )
-                )
-                if not ok:
-                    sys.exit(1)
-                return
-
-            if ok:
-                if note_id:
-                    console.print(
-                        f"[green]✅ Note published successfully! Note ID: {note_id}[/green]"
-                    )
-                else:
-                    console.print("[green]✅ Note published successfully![/green]")
-            else:
-                console.print("[red]❌ Publish may have failed. Check your profile.[/red]")
-                sys.exit(1)
     except FileNotFoundError as e:
         console.print(f"[red]❌ {e}[/red]")
         sys.exit(1)
+    except LoginError:
+        console.print(
+            "[red]❌ Publish failed: creator publish session is unavailable in the "
+            "automated browser. If you are already logged in in Chrome, the creator "
+            "session may still be non-reusable by automation.[/red]"
+        )
+        sys.exit(1)
     except Exception as e:
         console.print(f"[red]❌ Publish failed: {e}[/red]")
+        sys.exit(1)
+
+
+@cli.command("post-real")
+@click.argument("title")
+@click.option("--image", "images", multiple=True, required=True,
+              type=click.Path(exists=True), help="Image file to upload (can be repeated)")
+@click.option("--content", default="", help="Note body/description text")
+@click.option("--json", "as_json", is_flag=True, help="Output publish result JSON")
+@click.option(
+    "--cdp-url",
+    default=DEFAULT_CHROME_CDP_URL,
+    show_default=True,
+    help="Chrome DevTools endpoint for your real logged-in Chrome session.",
+)
+def post_real(title: str, images: tuple[str, ...], content: str, as_json: bool, cdp_url: str):
+    """Publish a new image note via a real Chrome session connected over CDP.
+
+    This reuses a real Chrome profile/session instead of the default camoufox browser.
+    """
+    import os
+
+    abs_paths = [os.path.abspath(p) for p in images]
+
+    console.print(f"[dim]Publishing via real Chrome: {title}[/dim]")
+    console.print(f"[dim]Images: {', '.join(os.path.basename(p) for p in abs_paths)}[/dim]")
+    console.print(f"[dim]CDP: {cdp_url}[/dim]")
+    if content:
+        console.print(f"[dim]Content: {content[:50]}{'...' if len(content) > 50 else ''}[/dim]")
+
+    try:
+        with get_real_chrome_client(cdp_url) as client:
+            _publish_note_with_client(
+                client,
+                title=title,
+                abs_paths=abs_paths,
+                content=content,
+                as_json=as_json,
+            )
+    except FileNotFoundError as e:
+        console.print(f"[red]❌ {e}[/red]")
+        sys.exit(1)
+    except LoginError:
+        console.print(
+            "[red]❌ Real Chrome publish failed: the connected Chrome session still hit "
+            "creator login / verification while publishing.[/red]"
+        )
+        sys.exit(1)
+    except Exception as e:
+        console.print(f"[red]❌ Real Chrome publish failed: {e}[/red]")
         sys.exit(1)
 
 

--- a/xhs_cli/client.py
+++ b/xhs_cli/client.py
@@ -15,6 +15,8 @@ from .exceptions import DataFetchError, LoginError
 
 logger = logging.getLogger(__name__)
 
+CREATOR_PUBLISH_URL = "https://creator.xiaohongshu.com/publish/publish"
+
 # Shared JavaScript function to unwrap Vue reactive refs from __INITIAL_STATE__.
 # Vue wraps values in reactive Proxy objects with _value/dep structure.
 UNWRAP_JS = """
@@ -155,6 +157,30 @@ class XhsClient:
             self._browser = None
             self._page = None
             logger.info("Browser closed.")
+
+    def probe_creator_publish_access(self) -> bool | None:
+        """Check whether the current session can access the creator publish page."""
+        if not self._page:
+            raise RuntimeError("Browser not started")
+
+        try:
+            self._goto(
+                CREATOR_PUBLISH_URL,
+                timeout=30000,
+                wait_min=1,
+                wait_max=2,
+                context="loading creator publish page",
+            )
+        except LoginError:
+            return False
+        except Exception as exc:
+            logger.warning("Creator publish access probe failed due to transient error: %s", exc)
+            return None
+
+        current_url = (self._page.url or "").lower()
+        if "creator.xiaohongshu.com/login" in current_url or "redirectreason=401" in current_url:
+            return False
+        return current_url.startswith("https://creator.xiaohongshu.com/")
 
     # ===== Search =====
 
@@ -734,7 +760,7 @@ class XhsClient:
         """
         self._goto(
             "https://www.xiaohongshu.com",
-            timeout=15000,
+            timeout=30000,
             wait_min=1,
             wait_max=2,
             context="loading homepage for self info",
@@ -1006,7 +1032,7 @@ class XhsClient:
             if not os.path.isfile(path):
                 raise FileNotFoundError(f"Image not found: {path}")
 
-        publish_url = "https://creator.xiaohongshu.com/publish/publish"
+        publish_url = CREATOR_PUBLISH_URL
         logger.info("Navigating to publish page: %s", publish_url)
         self._goto(
             publish_url,
@@ -1438,10 +1464,35 @@ class XhsClient:
         wait_max: float = 2.0,
         context: str = "loading page",
     ):
-        """Navigate to URL and fail fast if redirected to risk-control pages."""
-        self._page.goto(url, wait_until=wait_until, timeout=timeout)
+        """Navigate to URL and fail fast if redirected to risk-control pages.
+
+        Xiaohongshu sometimes streams enough HTML to be usable before
+        Playwright observes the requested load milestone. When that happens,
+        keep the partially loaded page if we can still hydrate
+        `window.__INITIAL_STATE__` from inline HTML.
+        """
+        nav_error = None
+        try:
+            self._page.goto(url, wait_until=wait_until, timeout=timeout)
+        except Exception as exc:
+            nav_error = exc
         self._human_wait(wait_min, wait_max)
         self._raise_if_blocked(context, include_body=True)
+        hydrated = self._hydrate_initial_state_from_html()
+        if nav_error:
+            has_body = False
+            try:
+                has_body = bool((self._page.text_content("body") or "").strip())
+            except Exception:
+                pass
+            if hydrated or has_body:
+                logger.warning(
+                    "Page.goto timed out while %s; continuing with partially loaded page at %s",
+                    context,
+                    getattr(self._page, "url", url),
+                )
+                return
+            raise nav_error
 
     def _detect_block_reason(self, include_body: bool = False) -> str:
         """Detect whether current page is a security verification/risk-control page."""
@@ -1498,6 +1549,8 @@ class XhsClient:
                 )
                 if result:
                     return
+                if self._hydrate_initial_state_from_html():
+                    return
                 self._raise_if_blocked("waiting for initial state", include_body=False)
             except LoginError:
                 raise
@@ -1524,6 +1577,11 @@ class XhsClient:
                 if self._page.evaluate(js_condition):
                     logger.debug("%s ready after %.1fs", desc, time.time() - start)
                     return
+                if self._hydrate_initial_state_from_html() and self._page.evaluate(js_condition):
+                    logger.debug(
+                        "%s hydrated from inline HTML after %.1fs", desc, time.time() - start
+                    )
+                    return
                 self._raise_if_blocked(f"waiting for {desc}", include_body=False)
             except LoginError:
                 raise
@@ -1538,3 +1596,57 @@ class XhsClient:
     def _human_wait(self, min_sec: float = 1.0, max_sec: float = 3.0):
         """Wait a random human-like interval."""
         time.sleep(random.uniform(min_sec, max_sec))
+
+    def _hydrate_initial_state_from_html(self) -> bool:
+        """Best-effort recovery when inline state exists in HTML but not on window.
+
+        Xiaohongshu sometimes ships `window.__INITIAL_STATE__=...` inside an inline
+        `<script>` tag, but the variable is unavailable by the time Playwright
+        evaluates the page. Replaying that inline assignment restores the same
+        state object and lets existing extraction paths keep working.
+        """
+        if not self._page:
+            return False
+
+        try:
+            if self._page.evaluate(
+                "() => window.__INITIAL_STATE__ !== undefined && window.__INITIAL_STATE__ !== null"
+            ):
+                return True
+        except Exception:
+            pass
+
+        try:
+            html = self._page.content()
+        except Exception:
+            return False
+
+        match = re.search(
+            r"<script>\s*(window\.__INITIAL_STATE__\s*=\s*[\s\S]*?)</script>",
+            html,
+            flags=re.S,
+        )
+        if not match:
+            return False
+
+        script = match.group(1).strip()
+        try:
+            hydrated = self._page.evaluate(
+                """(scriptText) => {
+                    if (window.__INITIAL_STATE__ !== undefined &&
+                        window.__INITIAL_STATE__ !== null) {
+                        return true;
+                    }
+                    eval(scriptText);
+                    return window.__INITIAL_STATE__ !== undefined &&
+                           window.__INITIAL_STATE__ !== null;
+                }""",
+                script,
+            )
+        except Exception:
+            return False
+
+        if hydrated:
+            logger.debug("Hydrated window.__INITIAL_STATE__ from inline HTML script")
+            return True
+        return False

--- a/xhs_cli/real_chrome.py
+++ b/xhs_cli/real_chrome.py
@@ -1,0 +1,56 @@
+"""Helpers for connecting xhs-cli to a real Chrome session via CDP."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from playwright.sync_api import sync_playwright
+
+from .client import XhsClient
+
+DEFAULT_CHROME_CDP_URL = "http://127.0.0.1:9222"
+
+
+def build_cdp_launch_help(cdp_url: str) -> str:
+    """Return a short remediation message for enabling Chrome remote debugging."""
+    port = cdp_url.rsplit(":", 1)[-1] if ":" in cdp_url else "9222"
+    return (
+        f"Cannot connect to real Chrome at {cdp_url}. "
+        "Quit Chrome completely, then relaunch it with remote debugging enabled. "
+        "Example (macOS):\n"
+        f'  /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome '
+        f"--remote-debugging-port={port} --profile-directory=Default"
+    )
+
+
+@contextmanager
+def get_real_chrome_client(cdp_url: str = DEFAULT_CHROME_CDP_URL) -> Iterator[XhsClient]:
+    """Connect to a real Chrome session and expose it as an XhsClient-like object."""
+    with sync_playwright() as playwright:
+        try:
+            browser = playwright.chromium.connect_over_cdp(cdp_url)
+        except Exception as exc:  # pragma: no cover - exact playwright error varies
+            raise RuntimeError(build_cdp_launch_help(cdp_url)) from exc
+
+        contexts = list(browser.contexts)
+        if not contexts:
+            raise RuntimeError(
+                "Connected to Chrome, but no browser context is available. "
+                "Open at least one normal Chrome window in that session and retry."
+            )
+
+        context = contexts[0]
+        page = context.new_page()
+
+        client = XhsClient({})
+        client._browser = browser
+        client._page = page
+
+        try:
+            yield client
+        finally:
+            try:
+                page.close()
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- add creator publish preflight probing to avoid reporting login success when `creator.xiaohongshu.com` is still blocked
- add `post-real` command to publish through an already logged-in real Chrome session over CDP
- harden navigation/data waits by hydrating `window.__INITIAL_STATE__` from inline HTML when Playwright load milestones time out
- extend CLI/client tests and docs for new publish flows and creator-login guidance

## Why
`xhs post` could fail late when main-site login was valid but creator publishing was not reusable. This PR moves that failure detection earlier and provides a practical recovery path.

## Validation
- `uv run pytest -q`
- `uv run ruff check .`
