### PR TITLE
Migrate read commands off removed __INITIAL_STATE__ to signed XHR capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **Read commands no longer depend on `window.__INITIAL_STATE__`**, which
+  Xiaohongshu's current web frontend no longer injects (it renders purely via
+  client-side XHR). `search`, `feed`, `whoami`, and `read` were timing out;
+  they now work again.
+
+### Changed
+
+- Added `XhsClient._navigate_and_capture()`, which navigates to a page and reads
+  the body of the SPA's own validly-signed XHR response via
+  `page.expect_response`, instead of forging API calls.
+- Migrated `search_notes` (`/api/sns/web/v1/search/notes`), `get_feed`
+  (`/api/sns/web/v1/homefeed`, scroll-triggered), `get_self_info`
+  (`/api/sns/web/v2/user/me`), and `get_note_comments`
+  (`/api/sns/web/v2/comment/page`) to this mechanism. `get_note_detail` scrapes
+  the rendered DOM, since direct note opens fire no detail XHR.
+
+### Known limitations
+
+- Profile-page commands (`user`, `user-posts`, `followers`, `following`,
+  `favorites`) still rely on `__INITIAL_STATE__`. Under headless automation all
+  `/user/profile/<id>` pages redirect to a risk-control captcha, so they cannot
+  be migrated with the same approach and remain non-functional for now.
+- `read` note-detail fields are best-effort DOM scrapes; engagement counts may
+  be approximate.
+
+### Validation
+
+- `pytest tests/test_client.py tests/test_cli.py tests/test_auth.py` → 82 passed.
+- Live-verified against a logged-in account: `search`, `feed`, `whoami`, `read`.
+
 ## v0.1.4 - 2026-03-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -202,17 +202,17 @@ xhs --help
 ```
 CLI (click) → XhsClient (camoufox 浏览器)
                   ↓ 导航到真实页面
-              window.__INITIAL_STATE__ → 提取结构化数据
+              捕获页面自身的签名 XHR 响应 → 提取结构化数据
 ```
 
-使用 [camoufox](https://github.com/daijro/camoufox)（反指纹 Firefox）像真实用户一样浏览小红书。数据从页面的 `window.__INITIAL_STATE__` 中提取，与正常浏览完全一致。
+使用 [camoufox](https://github.com/daijro/camoufox)（反指纹 Firefox）像真实用户一样浏览小红书。读取类命令捕获页面自己发出的、已合法签名的 XHR 接口响应（而非伪造 API 请求），与正常浏览完全一致。
 
 ## 工作原理
 
 1. **认证** — 优先读取 `~/.xhs-cli/cookies.json`；未命中时通过 browser-cookie3 从本地 Chrome 提取 cookie。`xhs login --qrcode` 使用 browser-assisted 扫码登录，并在终端渲染二维码（`▀ ▄ █`）。
 2. **登录态校验** — 登录后会校验会话是否为有效非 guest 会话，并做 feed/search 可用性探活；探活失败会提示重新登录。
 3. **浏览** — 使用 camoufox 导航到真实页面，所有流量与正常用户浏览一致。
-4. **数据提取** — 从 `window.__INITIAL_STATE__` 提取结构化数据。
+4. **数据提取** — 捕获页面自身发出的、已合法签名的 XHR 接口响应（`search/notes`、`homefeed`、`user/me`、`comment/page` 等）；笔记正文等无对应接口的内容回退到读取已渲染 DOM。
 5. **Token 缓存** — 搜索/Feed 后 `xsec_token` 自动缓存到 `~/.xhs-cli/token_cache.json`。
 6. **互动操作** — 点赞、收藏、评论通过点击真实 DOM 按钮实现。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -201,17 +201,17 @@ xhs --help
 ```
 CLI (click) → XhsClient (camoufox browser)
                   ↓ navigate to real pages
-              window.__INITIAL_STATE__ → extract structured data
+              capture the page's own signed XHR responses → extract data
 ```
 
-Uses [camoufox](https://github.com/daijro/camoufox) (anti-fingerprint Firefox) to browse Xiaohongshu like a real user. Data is extracted from `window.__INITIAL_STATE__` — completely indistinguishable from normal browsing.
+Uses [camoufox](https://github.com/daijro/camoufox) (anti-fingerprint Firefox) to browse Xiaohongshu like a real user. Read commands capture the page's own validly-signed XHR responses (rather than forging API calls) — completely indistinguishable from normal browsing.
 
 ## How It Works
 
 1. **Authentication** — First reads `~/.xhs-cli/cookies.json`; if missing, extracts cookies from local Chrome via browser-cookie3. `xhs login --qrcode` uses browser-assisted QR login with terminal half-block rendering (`▀ ▄ █`).
 2. **Session Validation** — After login, the CLI verifies that the session is non-guest and probes feed/search usability. If probe fails, it asks for re-login.
 3. **Browsing** — Each operation navigates to real pages using camoufox, making all traffic look like normal user browsing.
-4. **Data Extraction** — Structured data is pulled from `window.__INITIAL_STATE__`.
+4. **Data Extraction** — Captures the page's own validly-signed XHR responses (`search/notes`, `homefeed`, `user/me`, `comment/page`, …); note body and other content without a backing endpoint falls back to reading the rendered DOM.
 5. **Token Caching** — After search/feed, `xsec_token` is auto-cached to `~/.xhs-cli/token_cache.json`.
 6. **Interactions** — Like, favorite, and comment work by clicking actual DOM buttons.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from xhs_cli.client import XhsClient
 from xhs_cli.exceptions import DataFetchError, LoginError
@@ -44,35 +45,144 @@ class _FakeWaitPage:
         return self._body
 
 
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeExpectContext:
+    def __init__(self, page):
+        self._page = page
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        if self._page.raise_timeout:
+            raise PlaywrightTimeoutError("no response")
+        return False
+
+    @property
+    def value(self):
+        return _FakeResponse(self._page.payload)
+
+
+class _FakeCapturePage:
+    """Minimal page that drives _navigate_and_capture without a real browser."""
+
+    def __init__(self, url, payload=None, raise_timeout=False):
+        self.url = url
+        self.payload = payload
+        self.raise_timeout = raise_timeout
+
+    def expect_response(self, _predicate, timeout=0):
+        return _FakeExpectContext(self)
+
+    def goto(self, *_args, **_kwargs):
+        return None
+
+    def mouse_wheel(self, *_args, **_kwargs):
+        return None
+
+    @property
+    def mouse(self):
+        page = self
+
+        class _Mouse:
+            def wheel(self, *_a, **_k):
+                return None
+
+        return _Mouse()
+
+    def text_content(self, _selector):
+        return ""
+
+
+def _no_wait(client, monkeypatch):
+    monkeypatch.setattr(client, "_human_wait", lambda *_a, **_k: None)
+
+
+class TestNavigateAndCapture:
+    def test_returns_json_body_on_success(self, monkeypatch):
+        client = XhsClient({})
+        client._page = _FakeCapturePage(
+            "https://www.xiaohongshu.com/explore", payload={"ok": 1}
+        )
+        _no_wait(client, monkeypatch)
+        assert client._navigate_and_capture("u", "/api/x") == {"ok": 1}
+
+    def test_raises_data_fetch_error_on_timeout(self, monkeypatch):
+        client = XhsClient({})
+        client._page = _FakeCapturePage(
+            "https://www.xiaohongshu.com/explore", raise_timeout=True
+        )
+        _no_wait(client, monkeypatch)
+        with pytest.raises(DataFetchError, match="/api/x"):
+            client._navigate_and_capture("u", "/api/x")
+
+    def test_raises_login_error_when_redirected_to_captcha(self, monkeypatch):
+        client = XhsClient({})
+        client._page = _FakeCapturePage(
+            "https://www.xiaohongshu.com/website-login/captcha?verifyUuid=abc",
+            raise_timeout=True,
+        )
+        _no_wait(client, monkeypatch)
+        with pytest.raises(LoginError, match="security verification"):
+            client._navigate_and_capture("u", "/api/x")
+
+
+class TestSearchAndFeedMapping:
+    def test_search_returns_api_items(self, monkeypatch):
+        client = XhsClient({})
+        envelope = {"data": {"items": [{"id": "n1"}, {"id": "n2"}], "has_more": True}}
+        monkeypatch.setattr(client, "_navigate_and_capture", lambda *a, **k: envelope)
+        assert client.search_notes("food") == [{"id": "n1"}, {"id": "n2"}]
+
+    def test_search_returns_empty_when_no_items(self, monkeypatch):
+        client = XhsClient({})
+        monkeypatch.setattr(client, "_navigate_and_capture", lambda *a, **k: {"data": {}})
+        assert client.search_notes("food") == []
+
+    def test_feed_returns_api_items(self, monkeypatch):
+        client = XhsClient({})
+        envelope = {"data": {"items": [{"id": "f1"}], "cursor_score": "x"}}
+        monkeypatch.setattr(client, "_navigate_and_capture", lambda *a, **k: envelope)
+        assert client.get_feed() == [{"id": "f1"}]
+
+
+class TestGetSelfInfo:
+    def test_wraps_user_me_as_basic_info(self, monkeypatch):
+        client = XhsClient({})
+        data = {"nickname": "Me", "user_id": "u1", "red_id": "r1"}
+        monkeypatch.setattr(
+            client, "_navigate_and_capture", lambda *a, **k: {"data": data}
+        )
+        assert client.get_self_info() == {"basicInfo": data}
+
+    def test_returns_empty_when_no_data(self, monkeypatch):
+        client = XhsClient({})
+        monkeypatch.setattr(client, "_navigate_and_capture", lambda *a, **k: {"data": {}})
+        assert client.get_self_info() == {}
+
+
 class TestGetNoteComments:
-    def test_extracts_note_comments_and_applies_max_limit(self):
+    def test_extracts_note_comments_and_applies_max_limit(self, monkeypatch):
         client = XhsClient({})
-        client._page = _FakePage(
-            "https://www.xiaohongshu.com/explore/note123",
-            {"comments": [{"id": "c1"}, {"id": "c2"}]},
-        )
+        envelope = {"data": {"comments": [{"id": "c1"}, {"id": "c2"}]}}
+        monkeypatch.setattr(client, "_navigate_and_capture", lambda *a, **k: envelope)
+        assert client.get_note_comments("note123", max_comments=1) == [{"id": "c1"}]
 
-        comments = client.get_note_comments("note123", max_comments=1)
-        assert comments == [{"id": "c1"}]
-
-    def test_navigates_to_target_note_when_page_mismatch(self, monkeypatch):
+    def test_returns_empty_when_capture_fails(self, monkeypatch):
         client = XhsClient({})
-        client._page = _FakePage(
-            "https://www.xiaohongshu.com/explore/other",
-            [{"id": "c1"}],
-        )
-        called = {"value": False}
 
-        def _fake_nav(note_id: str, xsec_token: str):
-            called["value"] = True
-            assert note_id == "note123"
-            assert xsec_token == "tok"
-            client._page.url = f"https://www.xiaohongshu.com/explore/{note_id}"
+        def _raise(*_a, **_k):
+            raise DataFetchError("blocked")
 
-        monkeypatch.setattr(client, "_navigate_to_note", _fake_nav)
-        comments = client.get_note_comments("note123", xsec_token="tok", max_comments=10)
-        assert called["value"]
-        assert comments == [{"id": "c1"}]
+        monkeypatch.setattr(client, "_navigate_and_capture", _raise)
+        assert client.get_note_comments("note123", xsec_token="tok") == []
 
 
 class TestPublishResultHeuristic:

--- a/xhs_cli/client.py
+++ b/xhs_cli/client.py
@@ -1,7 +1,10 @@
 """Xiaohongshu browser-based client using camoufox.
 
-All operations navigate to pages and extract data from window.__INITIAL_STATE__,
-exactly like a real user browsing. This avoids API-level risk control (300011).
+Operations navigate to real pages in a stealth browser, exactly like a user
+browsing. Read commands capture the page's own validly-signed XHR responses
+(see ``_navigate_and_capture``) instead of forging API calls, which avoids
+API-level risk control (300011). A few legacy paths still read the now-removed
+window.__INITIAL_STATE__ and are pending migration.
 """
 
 from __future__ import annotations
@@ -10,6 +13,8 @@ import logging
 import random
 import re
 import time
+
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from .exceptions import DataFetchError, LoginError
 
@@ -161,60 +166,76 @@ class XhsClient:
     def search_notes(self, keyword: str) -> list[dict]:
         """Search notes by keyword.
 
-        Navigates to search_result page and extracts from __INITIAL_STATE__.search.feeds.
+        Navigates to the search_result page and captures the SPA's own signed
+        /api/sns/web/v1/search/notes XHR response.
         """
         import urllib.parse
         params = urllib.parse.urlencode({"keyword": keyword, "source": "web_explore_feed"})
         url = f"https://www.xiaohongshu.com/search_result?{params}"
 
         logger.info("Searching: %s", keyword)
-        self._goto(
+        envelope = self._navigate_and_capture(
             url,
-            timeout=20000,
-            wait_min=1,
-            wait_max=2,
+            "/api/sns/web/v1/search/notes",
+            method="POST",
             context="loading search page",
+            timeout=20000,
         )
 
-        # Wait for search.feeds to be populated by Vue
-        self._wait_for_data(
-            """() => {
-                const s = window.__INITIAL_STATE__;
-                if (!s || !s.search) return false;
-                const f = s.search.feeds;
-                if (!f) return false;
-                const d = f._rawValue || f._value || f.value || f;
-                return Array.isArray(d) || (d && typeof d === 'object');
-            }""",
-            timeout=15.0,
-            desc="search.feeds",
-            raise_on_timeout=True,
-        )
-
-        # Extract search feeds
-        result = self._page.evaluate(
-            """() => {
-"""
-            + UNWRAP_JS
-            + """
-            const s = window.__INITIAL_STATE__;
-            if (!s || !s.search || !s.search.feeds) return null;
-            return unwrap(s.search.feeds, 0);
-        }"""
-        )
-
-        if not result:
-            logger.warning("No search results found in __INITIAL_STATE__")
+        items = (envelope or {}).get("data", {}).get("items")
+        if not items:
+            logger.warning("No search results in API response")
             return []
-
-        return result if isinstance(result, list) else []
+        return [it for it in items if isinstance(it, dict)]
 
     # ===== Note Detail =====
 
-    def get_note_detail(self, note_id: str, xsec_token: str = "") -> dict:
-        """Get note detail by navigating to the explore page.
+    # JS that scrapes the rendered note page. Modern Xiaohongshu no longer
+    # exposes __INITIAL_STATE__ for note detail and fires no dedicated detail
+    # XHR on direct open, so we read the DOM the SPA renders.
+    _NOTE_DETAIL_JS = """() => {
+        const txt = (sels) => {
+            for (const s of sels) {
+                const e = document.querySelector(s);
+                if (e && e.innerText && e.innerText.trim()) return e.innerText.trim();
+            }
+            return "";
+        };
+        const num = (sels) => {
+            const v = txt(sels);
+            return v || "0";
+        };
+        const title = txt(["#detail-title", ".note-content .title"]);
+        const desc = txt(["#detail-desc", ".note-content .desc", ".note-text"]);
+        const nickname = txt([".author-container .username",
+                              ".author-wrapper .username", ".info .name", ".username"]);
+        const ip = txt([".bottom-container .date span", ".bottom-container .date",
+                        ".note-content .date"]);
+        const imgs = Array.from(
+            document.querySelectorAll(".swiper-slide img, .note-slider-img, "
+                + ".media-container img")
+        ).map((e) => e.src).filter(Boolean);
+        return {
+            title: title,
+            desc: desc,
+            user: {nickname: nickname},
+            ip_location: ip,
+            image_list: imgs,
+            interact_info: {
+                liked_count: num([".like-wrapper .count", ".like-active ~ .count"]),
+                collected_count: num([".collect-wrapper .count"]),
+                comment_count: num([".chat-wrapper .count"]),
+                share_count: num([".share-wrapper .count"]),
+            },
+        };
+    }"""
 
-        Extracts from __INITIAL_STATE__.note.noteDetailMap.
+    def get_note_detail(self, note_id: str, xsec_token: str = "") -> dict:
+        """Get note detail by scraping the rendered note page DOM.
+
+        Best-effort: current Xiaohongshu embeds note content in the DOM rather
+        than exposing it via __INITIAL_STATE__ or a dedicated XHR, so some
+        fields may be empty if the page renders inconsistently under headless.
         """
         url = f"https://www.xiaohongshu.com/explore/{note_id}"
         if xsec_token:
@@ -229,42 +250,16 @@ class XhsClient:
             context=f"loading note {note_id}",
         )
 
-        self._wait_for_data(
-            """() => {
-                const s = window.__INITIAL_STATE__;
-                return s && s.note && s.note.noteDetailMap
-                    && Object.keys(s.note.noteDetailMap).length > 0;
-            }""",
-            timeout=15.0,
-            desc="note.noteDetailMap",
-            raise_on_timeout=True,
+        for _attempt in range(8):
+            result = self._page.evaluate(self._NOTE_DETAIL_JS)
+            if result and (result.get("desc") or result.get("title")):
+                return result
+            self._raise_if_blocked(f"loading note {note_id}", include_body=False)
+            time.sleep(1.0)
+
+        raise DataFetchError(
+            f"Failed to extract note detail for {note_id} (page did not render)"
         )
-
-        # Extract note detail
-        for _attempt in range(3):
-            result = self._page.evaluate("""() => {
-                if (window.__INITIAL_STATE__ &&
-                    window.__INITIAL_STATE__.note &&
-                    window.__INITIAL_STATE__.note.noteDetailMap) {
-                    return JSON.parse(JSON.stringify(
-                        window.__INITIAL_STATE__.note.noteDetailMap
-                    ));
-                }
-                return null;
-            }""")
-
-            if result:
-                # Find the note in the map
-                if note_id in result:
-                    return result[note_id]
-                # Try first key if note_id not found
-                if result:
-                    first_key = next(iter(result))
-                    return result[first_key]
-
-            time.sleep(0.5)
-
-        raise DataFetchError(f"Failed to extract note detail for {note_id}")
 
     # ===== User Profile =====
 
@@ -462,66 +457,22 @@ class XhsClient:
         from __INITIAL_STATE__.feed.
         """
         logger.info("Loading explore feed...")
-        self._goto(
+        envelope = self._navigate_and_capture(
             "https://www.xiaohongshu.com/explore",
-            timeout=20000,
+            "/api/sns/web/v1/homefeed",
+            method="POST",
+            context="loading explore feed",
+            timeout=25000,
             wait_min=2,
             wait_max=4,
-            context="loading explore feed",
-        )
-        self._wait_for_data(
-            """() => {
-                const s = window.__INITIAL_STATE__;
-                if (!s) return false;
-                const f = (s.feed && s.feed.feeds) ||
-                          (s.explore && s.explore.feeds) ||
-                          (s.homefeed && s.homefeed.feeds);
-                if (!f) return false;
-                const d = f._rawValue || f._value || f.value || f;
-                return Array.isArray(d) || (d && typeof d === 'object');
-            }""",
-            timeout=15.0,
-            desc="feed.feeds",
-            raise_on_timeout=True,
-        )
-        # Extract feed from explore page state
-        result = self._page.evaluate(
-            """() => {
-"""
-            + UNWRAP_JS
-            + """
-            const state = window.__INITIAL_STATE__;
-            if (!state) return null;
-
-            // Try multiple paths where feed data might live
-            // Path 1: state.feed.feeds (explore page)
-            if (state.feed && state.feed.feeds) {
-                return unwrap(state.feed.feeds, 0);
-            }
-            // Path 2: state.explore.feeds
-            if (state.explore && state.explore.feeds) {
-                return unwrap(state.explore.feeds, 0);
-            }
-            // Path 3: state.homefeed
-            if (state.homefeed && state.homefeed.feeds) {
-                return unwrap(state.homefeed.feeds, 0);
-            }
-            return null;
-        }"""
+            scroll=True,
         )
 
-        if not result:
-            logger.warning("No feed data found in __INITIAL_STATE__")
+        items = (envelope or {}).get("data", {}).get("items")
+        if not items:
+            logger.warning("No feed items in API response")
             return []
-
-        # result could be an array or an object wrapping an array
-        if isinstance(result, list):
-            return result
-        if isinstance(result, dict):
-            for key in ("value", "_value", "data", "list"):
-                if key in result and isinstance(result[key], list):
-                    return result[key]
-        return []
+        return [it for it in items if isinstance(it, dict)]
 
     # ===== Topics / Hashtags =====
 
@@ -726,99 +677,26 @@ class XhsClient:
     def get_self_info(self) -> dict:
         """Get current user's profile info.
 
-        Strategy:
-        1. Navigate to homepage and extract user_id from __INITIAL_STATE__
-           (checks multiple paths: user.currentUser, sidebar, etc.)
-        2. If user_id found, navigate to profile page for full info
-        3. Falls back to whatever data is available from homepage
+        Captures the SPA's own /api/sns/web/v2/user/me XHR response from the
+        homepage. The /user/profile/me page itself triggers risk-control
+        captcha under headless automation, so we deliberately avoid it; the
+        homepage endpoint returns nickname / user_id / red_id / desc / gender.
         """
-        self._goto(
+        envelope = self._navigate_and_capture(
             "https://www.xiaohongshu.com",
-            timeout=15000,
-            wait_min=1,
-            wait_max=2,
+            "/api/sns/web/v2/user/me",
+            method="GET",
             context="loading homepage for self info",
-        )
-        self._wait_for_data(
-            """() => {
-                const s = window.__INITIAL_STATE__;
-                if (!s) return false;
-                if (s.user && s.user.userPageData) return true;
-                if (s.user && s.user.currentUser) return true;
-                if (s.user && s.user.userInfo) return true;
-                if (s.sidebar && s.sidebar.user) return true;
-                return false;
-            }""",
-            timeout=10.0,
-            desc="user info",
-            raise_on_timeout=True,
+            timeout=15000,
         )
 
-        # Try to extract current user info from homepage state.
-        # The data might be in different paths depending on page version.
-        result = self._page.evaluate(
-            """() => {
-"""
-            + UNWRAP_JS
-            + """
-            const state = window.__INITIAL_STATE__;
-            if (!state) return null;
-
-            // Try multiple paths where current user info might live
-            const paths = [
-                state.user && state.user.userPageData,
-                state.user && state.user.currentUser,
-                state.user && state.user.info,
-                state.user && state.user.loginUser,
-                state.sidebar && state.sidebar.user,
-                state.app && state.app.user,
-            ];
-
-            for (const p of paths) {
-                if (p) {
-                    const data = unwrap(p, 0);
-                    if (data && typeof data === 'object' && Object.keys(data).length > 0) {
-                        return data;
-                    }
-                }
-            }
-
-            // Last resort: dump the entire user object for inspection
-            if (state.user) {
-                return unwrap(state.user, 0);
-            }
-            return null;
-        }"""
-        )
-
-        if not result:
+        data = (envelope or {}).get("data")
+        if not isinstance(data, dict) or not data:
             return {}
 
-        # Try to find user_id so we can navigate to profile for full info.
-        user_id = None
-        if isinstance(result, dict):
-            # Check multiple paths where userId might live
-            for sub_key in ["userInfo", "basicInfo", "basic_info"]:
-                sub = result.get(sub_key, {})
-                if isinstance(sub, dict):
-                    uid = sub.get("userId", "") or sub.get("user_id", "")
-                    if uid:
-                        user_id = uid
-                        break
-            if not user_id:
-                user_id = (result.get("userId", "") or result.get("user_id", "") or
-                           result.get("id", ""))
-
-        # If we got a user_id, fetch their full profile page for richer data
-        if user_id:
-            try:
-                full_info = self.get_user_info(user_id)
-                if full_info and isinstance(full_info, dict):
-                    return full_info
-            except Exception:
-                pass
-
-        return result
+        # /api/sns/web/v2/user/me is flat (nickname, user_id, red_id, desc,
+        # gender). Wrap it as basicInfo so the CLI's snake_case fallbacks apply.
+        return {"basicInfo": dict(data)}
 
     # ===== Comments via scroll =====
 
@@ -828,41 +706,31 @@ class XhsClient:
 
         Must be called after get_note_detail on the same note.
         """
-        # Ensure we are on the expected note page before extracting comments.
-        expected_path = f"/explore/{note_id}"
-        if expected_path not in self._page.url:
-            self._navigate_to_note(note_id, xsec_token)
+        # Navigate to the note page and capture its first signed
+        # /api/sns/web/v2/comment/page XHR response.
+        url = f"https://www.xiaohongshu.com/explore/{note_id}"
+        if xsec_token:
+            url += f"?xsec_token={xsec_token}&xsec_source=pc_feed"
 
-        # First get initial comments from __INITIAL_STATE__
-        comments_data = self._page.evaluate("""(noteId) => {
-            if (window.__INITIAL_STATE__ &&
-                window.__INITIAL_STATE__.note &&
-                window.__INITIAL_STATE__.note.noteDetailMap) {
-                const map = window.__INITIAL_STATE__.note.noteDetailMap;
-                const detail = map[noteId] || map[Object.keys(map)[0]];
-                if (detail) {
-                    const comments = detail.comments;
-                    if (comments !== undefined && comments !== null) {
-                        return JSON.parse(JSON.stringify(comments));
-                    }
-                }
-            }
-            return null;
-        }""", note_id)
-
-        if not comments_data:
+        try:
+            envelope = self._navigate_and_capture(
+                url,
+                "/api/sns/web/v2/comment/page",
+                method="GET",
+                context=f"loading comments for {note_id}",
+                timeout=20000,
+                wait_min=1.5,
+                wait_max=3,
+            )
+        except DataFetchError:
             return []
-        if isinstance(comments_data, dict):
-            for key in ("comments", "list", "data", "items"):
-                value = comments_data.get(key)
-                if isinstance(value, list):
-                    comments_data = value
-                    break
-        if not isinstance(comments_data, list):
+
+        comments = (envelope or {}).get("data", {}).get("comments")
+        if not isinstance(comments, list):
             return []
         if max_comments <= 0:
-            return comments_data
-        return comments_data[:max_comments]
+            return comments
+        return comments[:max_comments]
 
     # ===== Like / Unlike =====
 
@@ -1442,6 +1310,54 @@ class XhsClient:
         self._page.goto(url, wait_until=wait_until, timeout=timeout)
         self._human_wait(wait_min, wait_max)
         self._raise_if_blocked(context, include_body=True)
+
+    def _navigate_and_capture(
+        self,
+        url: str,
+        api_needle: str,
+        *,
+        method: str = None,
+        context: str = "loading page",
+        timeout: int = 20000,
+        wait_min: float = 1.0,
+        wait_max: float = 2.0,
+        scroll: bool = False,
+    ) -> dict:
+        """Navigate and capture the JSON body of the SPA's own API request.
+
+        Modern Xiaohongshu no longer exposes window.__INITIAL_STATE__; data is
+        fetched client-side via signed XHR calls. We let the page issue its own
+        (validly signed) request and read the response, rather than forging one.
+
+        Some pages (the explore feed) lazy-load their data on scroll, so
+        ``scroll=True`` nudges the page until the target request fires.
+        """
+        try:
+            with self._page.expect_response(
+                lambda r: api_needle in r.url
+                and (method is None or r.request.method == method),
+                timeout=timeout,
+            ) as resp_info:
+                self._page.goto(url, wait_until="domcontentloaded", timeout=timeout)
+                self._human_wait(wait_min, wait_max)
+                if scroll:
+                    for _ in range(4):
+                        self._page.mouse.wheel(0, 3000)
+                        self._human_wait(1.0, 1.8)
+            resp = resp_info.value
+        except PlaywrightTimeoutError:
+            self._raise_if_blocked(context, include_body=True)
+            raise DataFetchError(
+                f"API response for {api_needle} not received within "
+                f"{timeout / 1000:.1f}s while {context}"
+            )
+        self._raise_if_blocked(context, include_body=False)
+        try:
+            return resp.json()
+        except Exception:
+            raise DataFetchError(
+                f"Failed to parse JSON from {api_needle} while {context}"
+            )
 
     def _detect_block_reason(self, include_body: bool = False) -> str:
         """Detect whether current page is a security verification/risk-control page."""


### PR DESCRIPTION
## Problem

Xiaohongshu's current web frontend **no longer injects `window.__INITIAL_STATE__`** — pages now render purely client-side via signed XHR calls. Since every read command extracted data from that global, they all hang and time out against the live site today:

```
$ xhs search 美食
❌ Search failed: search.feeds not ready after 15.0s
$ xhs whoami
❌ Failed to get profile: user info not ready after 10.0s
```

The session and cookies are fine; the data is there (e.g. a search page renders 50+ note cards in the DOM), the scraper just looks in a place that no longer exists.

## Approach

Instead of scraping a global (or forging API calls, which trips risk control 300011), let the page issue its **own validly-signed** request and read the response. New helper:

```python
XhsClient._navigate_and_capture(url, api_needle, method=..., scroll=...)
```

It wraps `page.expect_response(...)` around navigation, returns the parsed JSON body, and raises a clear `LoginError` on a captcha redirect / `DataFetchError` on timeout.

## What's migrated (live-verified against a logged-in account)

| Command | Source |
|---------|--------|
| `search` | `POST /api/sns/web/v1/search/notes` → `data.items` |
| `feed` | `POST /api/sns/web/v1/homefeed` (scroll-triggered) → `data.items` |
| `whoami` | `GET /api/sns/web/v2/user/me` → wrapped as `{basicInfo: …}` |
| `read` comments | `GET /api/sns/web/v2/comment/page` → `data.comments` |
| `read` note body | rendered DOM (direct note opens fire no detail XHR) |

The captured `items[]` already match the exact `note_card.{display_title,user,interact_info}` shape the CLI render layer expects, so the render code is unchanged.

## Known limitations (documented in CHANGELOG)

- **Profile-page commands** (`user`, `user-posts`, `followers`, `following`, `favorites`) still use `__INITIAL_STATE__`. Under headless automation every `/user/profile/<id>` page redirects to a risk-control **captcha** (`website-login/captcha`), so they can't be migrated with this approach and remain non-functional for now. Left untouched rather than shipping unverifiable code.
- `read` note-detail fields are best-effort DOM scrapes; engagement counts may be approximate.

## Validation

- `pytest tests/test_client.py tests/test_cli.py tests/test_auth.py` → **82 passed** (unit tests for the new helper, mapping, and captcha/timeout paths added).
- Manually verified `search`, `feed`, `whoami`, `read` return real data end-to-end.

> Note: a separate environment fix was needed locally — `camoufox` 0.4.x bundles Firefox 135, whose juggler protocol is incompatible with `playwright` ≥ 1.60 (an uncaught page error crashes the driver via `pageError.location.url`). Pinning `playwright` to a Firefox-135-matching release (1.51.x) avoids it. Not included here since it's a dependency-pin decision for the maintainer.